### PR TITLE
Enable google analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -49,6 +49,9 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        gtag: {
+          trackingID: "G-EZQ5GRGJR3",
+        },
       }),
     ],
   ],


### PR DESCRIPTION
[문서](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag)에 따라 GA를 활성화한다.